### PR TITLE
Better default config

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -3,4 +3,4 @@ config APPHELLOWORLD_DEPENDENCIES
 	bool
 	default y
 	select LIBNOLIBC if !HAVE_LIBC
-	depends on LIBUKCARGO
+	select LIBUKCARGO

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = [ "rust-src" ]


### PR DESCRIPTION
This simple rust application has multiple implicit external dependencies like bindgen and rust-src components of `rustup`.
Even though they are not direct dependencies of this application but more related to `lib-rust` and `ukrust`, it would always make sense to have better defaults, avoiding manual configurations from users.

I added the `rust-toolchain.toml` file to set nightly and `rust-src` automatically during the build time.
Also, I changed `Config.uk` to *select* `LIBUKCARGO` as it is mandatory.
bindgen must still be downloaded manually, but one idea is to use [an unstable cargo feature](https://doc.rust-lang.org/cargo/reference/unstable.html#artifact-dependencies) to describe binary dependencies, but this PR doesn't include it.